### PR TITLE
Replace util.puts() with console.log()

### DIFF
--- a/lib/spruce.js
+++ b/lib/spruce.js
@@ -187,13 +187,13 @@ function init(opts) {
                 if (opts.useColor && color) {
                     logger[level] = function () {
 		    	var msg = sprintf.apply(this, arguments);
-                        util.puts('\x1B[' + color + 'm' + getStringContent(msg) +  '\x1B[0m');
+                        console.log('\x1B[' + color + 'm' + getStringContent(msg) +  '\x1B[0m');
                         runHandlers(msg);
                     };
                 } else {
                     logger[level] = function () {
 		    	var msg = sprintf.apply(this, arguments);
-                        util.puts(getStringContent(msg));
+                        console.log(getStringContent(msg));
                         runHandlers(msg);
                     };
                 }


### PR DESCRIPTION
Spruce was exploding a warning (node:39674) [DEP0027] DeprecationWarning: util.puts is deprecated. Use console.log instead.